### PR TITLE
[Feat] Represent a dataclass in UML.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 **pyclassanalyzer** automatically analyzes the class structure of a Python project and exports the results as a diagram.
 
 > [!IMPORTANT]  
-> Using the dataclass(@dataclass) may cause errors when working with older versions(< [v1.2025.4](https://github.com/plantuml/plantuml/releases/tag/v1.2025.4)) of the PlantUML engine.
+> We did not using the `dataclass` element supported by PlantUML.
+> Using the dataclass(@dataclass) may cause errors when working with older versions(prior to [v1.2025.4](https://github.com/plantuml/plantuml/releases/tag/v1.2025.4)) of the PlantUML. Therefore, we will create our own custom elements until the updated version of PlnatUML is widely adopted.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 **pyclassanalyzer** automatically analyzes the class structure of a Python project and exports the results as a diagram.
 
+> [!IMPORTANT]  
+> Using the dataclass(@dataclass) may cause errors when working with older versions(< [v1.2025.4](https://github.com/plantuml/plantuml/releases/tag/v1.2025.4)) of the PlantUML engine.
+
 ## Features
 
 - **Automatic Analysis:** Parses your Python codebase to extract class information (attributes, methods) and relationships (inheritance, composition, usage).

--- a/pyclassanalyzer/example/dataclass.py
+++ b/pyclassanalyzer/example/dataclass.py
@@ -1,0 +1,6 @@
+from dataclasses import dataclass
+
+@dataclass
+class Person:
+    name: str
+    age: int

--- a/pyclassanalyzer/generators/plantuml.py
+++ b/pyclassanalyzer/generators/plantuml.py
@@ -53,6 +53,10 @@ class PlantUMLGenerator:
             line.append(f"enum {node.name} {{")
         elif node.type_ == ClassType.ABSTRACT:
             line.append(f"abstract class {node.name} {{")
+        elif node.type_ == ClassType.DATACLASS:
+            line.append(f"class {node.name} << (D,#FFDD55) >> {{")
+            # >=2025.4 support
+            # line.append(f"dataclass {node.name} {{")
         else:
             line.append(f"class {node.name} {{")
         

--- a/pyclassanalyzer/network/classgraph.py
+++ b/pyclassanalyzer/network/classgraph.py
@@ -38,6 +38,7 @@ class ClassType(Enum):
     CLASS = "class" # default 
     ENUM = "enum"
     ABSTRACT = "abstract"
+    DATACLASS = "dataclass"
     
     def __str__(self):
         return self.value

--- a/pyclassanalyzer/visitors/visitor.py
+++ b/pyclassanalyzer/visitors/visitor.py
@@ -2,7 +2,7 @@ import ast
 from typing import Optional
 
 from pyclassanalyzer.network.classgraph import (
-    ClassGraph, ClassNode, Relation, RelationType, FunctionDef
+    ClassGraph, ClassNode, Relation, RelationType, FunctionDef, ClassType
 )
 
 class Visitor(ast.NodeVisitor):
@@ -24,6 +24,9 @@ class Visitor(ast.NodeVisitor):
         
         self.graph.add_node(class_)
         self.current_class = class_
+        
+        if 'dataclass' in class_.annotations:
+            class_.type_ = ClassType.DATACLASS
         
         # 상속 관계
         for base in node.bases:


### PR DESCRIPTION
##  Changes
- Represent a `dataclass` in UML using custom elements.(yellow color)
   - Using the dataclass(dataclass) may cause errors when working with older versions(prior to [v1.2025.4](https://github.com/plantuml/plantuml/releases/tag/v1.2025.4)) of the PlantUML. Therefore, we will create our own custom elements until the updated version of PlnatUML is widely adopted.

![image](https://github.com/user-attachments/assets/6f0aefa0-2630-4d69-b195-5bed21ff0c98)
