### PR TITLE
feat: Add focus feature - outgoing

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,3 +7,8 @@ classes = []
 
 [exception]
 name = "*Exception"
+
+[focus]
+is_enable = true
+root = "Visitor"
+depths = 2

--- a/pyclassanalyzer/network/classgraph.py
+++ b/pyclassanalyzer/network/classgraph.py
@@ -1,3 +1,4 @@
+from collections import deque
 from typing import Optional, List, Dict, Set
 from enum import Enum
 
@@ -238,6 +239,57 @@ class ClassGraph(BaseModel):
                 dfs(node_name)
         
         return stack[::-1]
+    
+    def focus_graph(self, root: str, depths: int):
+        """
+        Focus on the graph by filtering the nodes and relations.
+
+        Args:
+            root (str): The root node to focus on.
+            depths (int): The number of depths to focus on.
+
+        Returns:
+            ClassGraph: The focused graph.(New Graph)
+        """
+        if root not in self.nodes:
+            raise ValueError(f"Root node {root} not found in the graph")
+        
+        if depths <= 0:
+            raise ValueError(f"Depth must be greater than 0, but got {depths}")
+        
+        focused_graph = ClassGraph()
+        
+        if depths == 0:
+            focused_graph.add_node(self.nodes[root])
+            return focused_graph
+        
+        node_visited = set([root])
+        edge_visited = set()
+        queue = deque([(root, 0)])
+        
+        while queue:
+            curr_node, curr_level = queue.popleft()
+            
+            focused_graph.add_node(self.nodes[curr_node])
+            
+            # if we haven't reached max dcepth, explore the neighbors
+            if curr_level < depths:
+                for rel in self.get_outgoing_rels(curr_node):
+                    if rel.target not in node_visited:
+                        queue.append((rel.target, curr_level + 1))
+                        node_visited.add(rel.target)
+                        edge_visited.add(rel)
+                        
+        
+        for relation in edge_visited:
+            if relation.source in focused_graph.nodes and \
+                relation.target in focused_graph.nodes:
+                focused_graph.add_relation(relation)
+        
+        return focused_graph
+            
+        
+    
     
         
 

--- a/pyclassanalyzer/scanner/scanner.py
+++ b/pyclassanalyzer/scanner/scanner.py
@@ -86,6 +86,13 @@ class GraphScanner:
             project_name = os.path.basename(os.path.abspath(self.path))
             title = f"{project_name} Class Diagram"
         
+        if self.config.get('focus')['is_enable']:
+            focused_graph = self.graph.focus_graph(
+                root=self.config.get('focus')['root'],
+                depths=self.config.get('focus')['depths']
+            )
+            return self.plantuml_generator.save_to_file(focused_graph, output_path, title)
+        
         return self.plantuml_generator.save_to_file(self.graph, output_path, title)
     
     def get_plantuml_content(self, title: Optional[str] = None) -> str:


### PR DESCRIPTION
## Features
- Add outgoing focus feature. 

If user set `root` and `depths` in `focus`, you can get graph focused on root node. 

```toml
[focus]
is_enable = true
root = "Visitor"
depths = 2
```

## Screenshots
<img width="809" height="942" alt="image" src="https://github.com/user-attachments/assets/f2766ccf-e9c4-49c5-8c6b-d1cc1ae3ee01" />

## Issue
Ref #36 
